### PR TITLE
Fix air quality data processing error

### DIFF
--- a/Weather Page/main.js
+++ b/Weather Page/main.js
@@ -888,8 +888,13 @@ function findNearestAQHIStation(stations, position) {
   let minDistance = Infinity;
   
   stations.forEach(function(item) {
-    const λ2 = item.lng * Math.PI / 180;
-    const φ2 = item.lat * Math.PI / 180;
+    // 处理不同的数据结构：新格式使用location对象，旧格式直接使用lat/lng
+    const stationLat = item.location ? item.location.lat : item.lat;
+    const stationLng = item.location ? item.location.lng : item.lng;
+    const stationName = item.name || item.station;
+    
+    const λ2 = stationLng * Math.PI / 180;
+    const φ2 = stationLat * Math.PI / 180;
     const λ1 = longitude * Math.PI / 180;
     const φ1 = latitude * Math.PI / 180;
     const x = (λ2 - λ1) * Math.cos((φ1 + φ2) / 2);
@@ -898,7 +903,7 @@ function findNearestAQHIStation(stations, position) {
     
     if (distance < minDistance) {
       minDistance = distance;
-      minStation = { name: item.station, distance: distance };
+      minStation = { name: stationName, distance: distance };
     }
   });
   
@@ -1028,7 +1033,9 @@ async function initializeWeatherPage() {
 // 处理空气质量数据
 async function processAirQualityData(aqhiStations, position) {
   try {
-    const nearestAQHIStation = findNearestAQHIStation(aqhiStations, position);
+    // 确保传递的是stations数组而不是整个对象
+    const stations = aqhiStations.stations || aqhiStations;
+    const nearestAQHIStation = findNearestAQHIStation(stations, position);
     
     if (nearestAQHIStation) {
       const aqhiData = await getAirQualityData();


### PR DESCRIPTION
Fix `TypeError: stations.forEach is not a function` by correctly extracting the stations array and adapting to the station data structure.

The `processAirQualityData` function was passing an object containing the stations array to `findNearestAQHIStation`, which expected the array directly. Additionally, `findNearestAQHIStation` was updated to correctly parse station latitude, longitude, and name from the new data format (which uses `location.lat`/`location.lng` and `name`).

---
<a href="https://cursor.com/background-agent?bcId=bc-7b0f8b4d-95c2-44bf-a528-63dc786a57db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b0f8b4d-95c2-44bf-a528-63dc786a57db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

